### PR TITLE
Add Travis-CI integration for automated building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+sudo: required
+language: bash
+services:
+  - docker
+
+env:
+  global:
+    - SOGO_VERSION=v3.2.10
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+
+
+script:
+  # Initial build with default parameters
+  - docker build --build-arg VERSION="${SOGO_VERSION}" -t sogo:testing .
+
+after_success:
+  # Push successful builds of the master branch to Docker Hub
+  # You need to define $DOCKER_REPO_PREFIX, $DOCKER_REPO_NAME, $DOCKER_USERNAME and $DOCKER_PASSWORD in your Travis settings.
+  # $DOCKER_REPO_PREFIX - Organisation of username who owns the repo on Docker Hub
+  # $DOCKER_REPO_NAME   - Repository name on Docker Hub
+  # $DOCKER_USERNAME    - Docker Hub username used to push the image
+  # $DOCKER_PASSWORD    - Password of the Docker Hub user used to push the image
+  # See https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$DOCKER_REPO_PREFIX" != "" ] && [ "$DOCKER_REPO_NAME" != "" ] && [ "$DOCKER_USERNAME" != "" ] && [ "$DOCKER_PASSWORD" != "" ]; then
+    tools/tagging.sh "${DOCKER_REPO_PREFIX}/${DOCKER_REPO_NAME}" "${INSP_VERSION:-latest}" "";
+    docker images "${DOCKER_REPO_PREFIX}/${DOCKER_REPO_NAME}";
+    echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin;
+    docker images --format "{{.Repository}}:{{.Tag}}" "${DOCKER_REPO_PREFIX}/${DOCKER_REPO_NAME}" | xargs -L 1 docker push ;
+    docker run --rm -v "$(pwd)/:/data/:ro" -e "DOCKERHUB_USERNAME=$DOCKER_USERNAME" -e "DOCKERHUB_PASSWORD=$DOCKER_PASSWORD" -e "DOCKERHUB_REPO_PREFIX=$DOCKER_REPO_PREFIX" -e "DOCKERHUB_REPO_NAME=$DOCKER_REPO_NAME" sheogorath/readme-to-dockerhub;
+    fi

--- a/tools/tagging.sh
+++ b/tools/tagging.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+if [ "$1" = "--help" ]; then
+    echo "
+    Usage of $0:
+        $0 <PREFIX> <VERSION> <SUFFIX>
+
+    Example:
+        $0 sogo 2.0.24 alpine
+    "
+fi
+
+PREFIX=${1:-sogo}
+VERSION=${2}
+[ "${3}" != "" ] && [ "${3}" != "debian" ] && SUFFIX="-${3}"
+
+
+
+if [ "$VERSION" != "" ]; then
+    docker tag sogo:testing "$PREFIX:$(echo "${VERSION}" | sed -e 's/^v//' | cut -d. -f1)${SUFFIX}"
+    docker tag sogo:testing "$PREFIX:$(echo "${VERSION}" | sed -e 's/^v//' | cut -d. -f1-2)${SUFFIX}"
+    docker tag sogo:testing "$PREFIX:$(echo "${VERSION}" | sed -e 's/^v//' | cut -d. -f1-3)${SUFFIX}"
+    [ "$SUFFIX" = "" ] && docker tag sogo:testing "$PREFIX:latest"
+else
+    echo "No version provided. Skipping tagging..."
+fi


### PR DESCRIPTION
Adding simple .travis.yml as we use it for inspircd-docker version 3 to
the repository that simply build the image without further testing for
now and uploads it correctly tagged on docker hub