### PR TITLE
Add ssmtp with entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN echo "untar SOPE sources" \
       libmemcached-dev \
       libcurl4-openssl-dev \
       tzdata \
+      zip \
+      zlib1g-dev \
+      ssmtp \
    && echo "compiling sope & sogo" \
    && cd /tmp/SOPE  \
    && ./configure --with-gnustep --enable-debug --disable-strip  \
@@ -51,10 +54,12 @@ RUN echo "untar SOPE sources" \
    && echo "create directories and enforce permissions" \
    && install -o sogo -g sogo -m 755 -d /var/run/sogo  \
    && install -o sogo -g sogo -m 750 -d /var/spool/sogo  \
-   && install -o sogo -g sogo -m 750 -d /var/log/sogo
+   && install -o sogo -g sogo -m 750 -d /var/log/sogo \
+   && chown -R sogo:sogo /etc/ssmtp/
    
 # add sogo.conf
 ADD sogo.default.conf /etc/sogo/sogo.conf
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 VOLUME /usr/local/lib/GNUstep/SOGo/WebServerResources
 
@@ -64,6 +69,8 @@ USER sogo
 
 # load env
 RUN . /usr/share/GNUstep/Makefiles/GNUstep.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 CMD [ "sogod", "-WONoDetach", "YES", "-WOPort", "20000", "-WOLogFile", "-", "-WOPidFile", "/tmp/sogo.pid"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+cat >/etc/ssmtp/ssmtp.conf <<EOF
+#
+# Config file for sSMTP sendmail
+#
+# The person who gets all mail for userids < 1000
+# Make this empty to disable rewriting.
+root=postmaster
+
+# The place where the mail goes. The actual machine name is required no
+# MX records are consulted. Commonly mailhosts are named mail.domain.com
+mailhub=${SSTMP_MAILSERVER}
+
+# Where will the mail seem to come from?
+#rewriteDomain=${SSMTP_DOMAIN}
+
+# The full hostname
+hostname=$HOSTNAME
+
+# Are users allowed to set their own From: address?
+# YES - Allow the user to specify their own From: address
+# NO - Use the system generated From: address
+FromLineOverride=YES
+
+AuthUser=${SSMTP_AUTHUSER}
+AuthPass=${SSMTP_AUTHPASS}
+AuthMethod=LOGIN
+
+UseTLS=YES
+UseSTARTTLS=YES
+EOF
+
+exec $@


### PR DESCRIPTION
SOGo lacks of some important SMTP support features, SSMTP should allow
to provide them without fixing SOGo

To use ssmtp simply provide the environment variables and set sendmail as mailing method.